### PR TITLE
support web888 with custom red pitaya based firmware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ log
 .venv
 .mypy_cache
 .pytest_cache
+__pycache__
 settings.yaml
 settings.yaml.new
 settings.yaml.safe

--- a/src/hfdl_observer/manage.py
+++ b/src/hfdl_observer/manage.py
@@ -285,11 +285,12 @@ class UniformConductor(AbstractConductor):
                     available.remove(receiver)
                     break
             else:
+                nl = '\n'
                 logger.warning(f'cannot allocate a receiver for {channel}')
-                logger.info(f'channels\n{"\n".join(repr(c) for c in channels)}')
-                logger.info(f'available left\n{"\n".join(str(a) for a in available)}')
-                logger.info(f'keeps\n{"\n".join(str(a) for a in keeps.values())}')
-                logger.info(f'starts\n{"\n".join(str(s) for s in starts)}')
+                logger.info(f'channels\n{nl.join(repr(c) for c in channels)}')
+                logger.info(f'available left\n{nl.join(str(a) for a in available)}')
+                logger.info(f'keeps\n{nl.join(str(a) for a in keeps.values())}')
+                logger.info(f'starts\n{nl.join(str(s) for s in starts)}')
 
     def orchestrate(self, targetted: dict[int, list[int]], fill_assigned: bool = False) -> list[data.ObservingChannel]:
         if not self.proxies:

--- a/src/receivers.py
+++ b/src/receivers.py
@@ -115,7 +115,7 @@ class Web888Receiver(LocalReceiver):
         raise NotImplementedError(str(self.__class__))
 
     def observable_widths(self) -> list[int]:
-        return [12]  # hardcoded to the value that kiwisdr uses.
+        return [self.config["client"]["channel_width"] // 1000]
 
 
 class DummyReceiver(Web888Receiver):


### PR DESCRIPTION
I don't expect this to actually be merged, just FYI this is what I had to change to set the channel width in settings.yaml (plus a change for python < 3.12)

If you wanted to run this yourself at this early stage, get the prebuilt image from [here](https://github.com/RaspSDR/red-pitaya-notes/releases/tag/v0.0.2) and extract in onto an SD card. In the apps/sdr_receiver/ folder, replace sdr_receiver.bit with [this file](https://github.com/user-attachments/files/19120454/sdr_receiver.zip). Once you load the card into the device and power up, SSH into it with creds root:changeme. Copy the contents of apps/sdr_receiver/ into ~/ (/root/), modify start.sh to point at the files in /root/ (apps/ is read only, at least for me). Replace sdr-receiver.c with the version [here](https://github.com/rpatel3001/red-pitaya-notes/tree/master/projects/hfdl_receiver/server), run `apk add gcc make`, run `make`, run `ip a` and note the IP, then run `./start.sh`.

On your hfdlobserver PC run tcp.py (in screen/tmux or a separate terminal or in the background) from [here](https://github.com/rpatel3001/red-pitaya-notes/tree/master/projects/hfdl_receiver/client) with `--device <ip of web888>`. Also from there grab redpitayarecorder.py and the example settings.yaml.

Adjust settings.yaml as needed and run hfdlobserver as normal.